### PR TITLE
Unable to delete expired object marker on versioned bucket in lifecycle rule

### DIFF
--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -113,12 +113,14 @@ func TestAccAlicloudOssBucketBasic(t *testing.T) {
 	name := fmt.Sprintf("tf-testacc-bucket-%d", rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceOssBucketConfigDependence)
 	hashcode1 := strconv.Itoa(expirationHash(map[string]interface{}{
-		"days": 365,
-		"date": "",
+		"days":                         365,
+		"date":                         "",
+		"expired_object_delete_marker": false,
 	}))
 	hashcode2 := strconv.Itoa(expirationHash(map[string]interface{}{
-		"days": 0,
-		"date": "2018-01-12",
+		"days":                         0,
+		"date":                         "2018-01-12",
+		"expired_object_delete_marker": false,
 	}))
 	hashcode3 := strconv.Itoa(transitionsHash(map[string]interface{}{
 		"days":                3,
@@ -139,6 +141,11 @@ func TestAccAlicloudOssBucketBasic(t *testing.T) {
 		"days":                0,
 		"created_before_date": "2021-11-11",
 		"storage_class":       "Archive",
+	}))
+	hashcode7 := strconv.Itoa(expirationHash(map[string]interface{}{
+		"days":                         0,
+		"date":                         "",
+		"expired_object_delete_marker": true,
 	}))
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -314,7 +321,7 @@ func TestAccAlicloudOssBucketBasic(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"lifecycle_rule.#":                                   "4",
+						"lifecycle_rule.#":                                   "5",
 						"lifecycle_rule.0.id":                                "rule1",
 						"lifecycle_rule.0.prefix":                            "path1/",
 						"lifecycle_rule.0.enabled":                           "true",
@@ -339,6 +346,11 @@ func TestAccAlicloudOssBucketBasic(t *testing.T) {
 						"lifecycle_rule.3.transitions." + hashcode5 + ".storage_class":       string(oss.StorageIA),
 						"lifecycle_rule.3.transitions." + hashcode6 + ".created_before_date": "2021-11-11",
 						"lifecycle_rule.3.transitions." + hashcode6 + ".storage_class":       string(oss.StorageArchive),
+
+						"lifecycle_rule.4.id":      "rule2",
+						"lifecycle_rule.4.prefix":  "path2/",
+						"lifecycle_rule.4.enabled": "true",
+						"lifecycle_rule.4.expiration." + hashcode7 + ".expired_object_delete_marker": "true",
 					}),
 				),
 			},
@@ -428,6 +440,11 @@ func TestAccAlicloudOssBucketBasic(t *testing.T) {
 						"lifecycle_rule.3.transitions." + hashcode5 + ".storage_class":       REMOVEKEY,
 						"lifecycle_rule.3.transitions." + hashcode6 + ".created_before_date": REMOVEKEY,
 						"lifecycle_rule.3.transitions." + hashcode6 + ".storage_class":       REMOVEKEY,
+
+						"lifecycle_rule.4.id":      REMOVEKEY,
+						"lifecycle_rule.4.prefix":  REMOVEKEY,
+						"lifecycle_rule.4.enabled": REMOVEKEY,
+						"lifecycle_rule.4.expiration." + hashcode7 + ".expired_object_delete_marker": REMOVEKEY,
 
 						"tags.%":           "0",
 						"tags.key1-update": REMOVEKEY,

--- a/website/docs/r/oss_bucket.html.markdown
+++ b/website/docs/r/oss_bucket.html.markdown
@@ -95,6 +95,15 @@ resource "alicloud_oss_bucket" "bucket-lifecycle" {
       date = "2018-01-12"
     }
   }
+  lifecycle_rule {
+    id      = "rule-expired-oject"
+    prefix  = "path2/"
+    enable  = true
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
 }
 
 resource "alicloud_oss_bucket" "bucket-lifecycle" {
@@ -287,6 +296,7 @@ The lifecycle_rule expiration object supports the following:
 
 * `date` - (Optional) Specifies the date after which you want the corresponding action to take effect. The value obeys ISO8601 format like `2017-03-09`.
 * `days` - (Optional, Type: int) Specifies the number of days after object creation when the specific rule action takes effect.
+* `expired_object_delete_marker` - (Optional, Type: boolean) On a versioned bucket (versioning-enabled or versioning-suspended bucket), you can add this element in the lifecycle configuration to direct OSS to delete expired object delete markers.
 
 `NOTE`: One and only one of "date" and "days" can be specified in one expiration configuration.
 


### PR DESCRIPTION
On a versioned bucket (versioning-enabled or versioning-suspended bucket), you can add this element in the lifecycle configuration to direct OSS to delete expired object delete markers.